### PR TITLE
SEMVER FOR THE SEMVER GOD

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
   "license": "MIT",
   "dependencies": {
     "@actions/core": "^1.2.4",
-    "axios": "^0.19.2"
+    "axios": "^0.19.2",
+    "semver": "^7.3.5"
   },
   "devDependencies": {
     "@types/jest": "^26.0.5",
     "@types/node": "^14.0.24",
+    "@types/semver": "^7.3.6",
     "@typescript-eslint/parser": "^3.6.1",
     "@zeit/ncc": "^0.22.3",
     "eslint": "^7.5.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core'
 import {readFileSync} from 'fs'
 import {join} from 'path'
 import axios from 'axios'
+import semver = require('semver')
 
 async function run(): Promise<void> {
   const cwd = core.getInput('cwd') || '.'
@@ -19,7 +20,7 @@ async function run(): Promise<void> {
       throw new Error('Got a bad response from npm')
     }
     const theirVersion = npmInfo.data['dist-tags'][npmTag]
-    const shouldDeploy = pkg.version > theirVersion
+    const shouldDeploy = semver.gt(pkg.version, theirVersion)
     if (shouldDeploy) {
       core.setOutput('deploy', 'true')
       core.info('Recommending a deploy')


### PR DESCRIPTION
Couldn't figure out the followup: yarn.lock FOR THE YARN THRONE!

Because it used the npm package registry instead of the yarn one, which
changed almost every line in yarn.lock.